### PR TITLE
Migrate to Indent Blankline 3

### DIFF
--- a/lua/visimp/languages/hcl.lua
+++ b/lua/visimp/languages/hcl.lua
@@ -2,7 +2,7 @@ local L = require('visimp.layer').new_layer('hcl')
 local layers = require('visimp.loader')
 
 L.default_config = {
-  -- wether to use or disable the terraform lsp
+  -- whether to use or disable the terraform lsp
   terraform = true,
   -- if the previous field is set to true, this object will be given to the LSP
   -- as configuration

--- a/lua/visimp/languages/latex.lua
+++ b/lua/visimp/languages/latex.lua
@@ -47,8 +47,9 @@ function L.preload()
   cfg = vim.tbl_deep_extend('force', cfg, L.config.lspconfig or {})
   if L.config.lsp ~= false then
     layers
-      .get('lsp')
-      .use_server('latex', L.config.lsp == nil, L.config.lsp or 'texlab', cfg)
+        .get('lsp')
+        .use_server('latex', L.config.lsp == nil, L.config.lsp or 'texlab', cfg)
   end
 end
+
 return L

--- a/lua/visimp/layers/blankline.lua
+++ b/lua/visimp/layers/blankline.lua
@@ -9,7 +9,7 @@ function L.packages()
 end
 
 function L.load()
-  get_module('indent_blankline').setup(L.config or {})
+  get_module('ibl').setup(L.config or {})
 end
 
 return L

--- a/lua/visimp/layers/indentline.lua
+++ b/lua/visimp/layers/indentline.lua
@@ -9,7 +9,7 @@ function L.packages()
 end
 
 function L.load()
-  get_module('indent_blankline').setup(L.config or {})
+  get_module('ibl').setup(L.config or {})
 end
 
 return L

--- a/lua/visimp/layers/lspformat.lua
+++ b/lua/visimp/layers/lspformat.lua
@@ -3,8 +3,8 @@ local get_module = require('visimp.bridge').get_module
 local get_layer = require('visimp.loader').get
 
 L.default_config = {
-  -- Aplies an autocommand to fix the behavious when quitting and wiring.
-  -- Because the formatter is async by deafult the code wouldn't be patched
+  -- Applies an autocommand to fix the behaviours when quitting and wiring.
+  -- Because the formatter is async by default the code wouldn't be patched
   -- without this fix when wiring and closing the editor at the same time.
   wq_fix = true,
 }

--- a/lua/visimp/loader.lua
+++ b/lua/visimp/loader.lua
@@ -1,4 +1,4 @@
---- Layer lodaer and (layer) dependency manager
+--- Layer loader and (layer) dependency manager
 -- @module visimp.loader
 local M = {
   layers = {},
@@ -25,12 +25,12 @@ function M.define_builtin(id)
   if not ok then
     error(
       'Requested invalid builtin layer: '
-        .. id
-        .. ' (resolved to '
-        .. 'visimp.layers.'
-        .. id
-        .. ')\n'
-        .. module
+      .. id
+      .. ' (resolved to '
+      .. 'visimp.layers.'
+      .. id
+      .. ')\n'
+      .. module
     )
   end
 

--- a/lua/visimp/pak/window.lua
+++ b/lua/visimp/pak/window.lua
@@ -1,4 +1,4 @@
---- The visimp package manager's popoup manager
+--- The visimp package manager's popup manager
 -- @module visimp.pak.window
 local M = {
   -- Configuration for the popup floating window
@@ -24,8 +24,8 @@ end
 --- Opens the floating window and relative buffer
 function M.open()
   local row, col =
-    math.ceil(((vim.o.lines - M.height) / 2) - 1),
-    math.ceil((vim.o.columns - M.width) / 2)
+      math.ceil(((vim.o.lines - M.height) / 2) - 1),
+      math.ceil((vim.o.columns - M.width) / 2)
 
   local cfg = {
     relative = 'editor',

--- a/lua/visimp/setup.lua
+++ b/lua/visimp/setup.lua
@@ -1,4 +1,4 @@
---- Setup funciton used to initialize visimp and load user's configurations
+--- Setup function used to initialize visimp and load user's configurations
 -- @module visimp.setup
 local loader = require('visimp.loader')
 local layer = require('visimp.layer')
@@ -81,8 +81,8 @@ function M.setup(cfg)
   if dep ~= nil then
     error(
       'The selected layers cause a cyclic dependency graph (faulty: '
-        .. dep
-        .. ')'
+      .. dep
+      .. ')'
     )
   end
 


### PR DESCRIPTION
A migration warning was being displayed when using any of the layers using Indent Blankine.
Migrated to version 3 as described here: https://github.com/lukas-reineke/indent-blankline.nvim/wiki/Migrate-to-version-3#commands

Also fixed some typos.