### PR TITLE
Add `lean` layer

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -13,11 +13,10 @@ require 'visimp' {
 
 Requiring the `visimp` script returns a "setup" function. This procedure
 is invoked by passing a description of your intended `visimp` configuration as
-parameter. In the example above, we are using an empty object (`{}`) as our 
+parameter. In the example above, we are using an empty object (`{}`) as our
 configuration, so no layer is enabled, besides the default ones. If you want
 to enable one, use its name as a new key (whose value will be an empty object
-for now). The available layers are listed at [the bottom of this
-page](#available-layers). The following configuration enables the `autopairs`,
+for now). The available layers are listed at [the bottom of this page](#available-layers). The following configuration enables the `autopairs`,
 `gitsigns`, and `outline` layers:
 
 ```lua
@@ -70,8 +69,7 @@ require 'visimp' {
 ```
 
 Before configuring a new layer, you're advised to take a look at its reference
-page. You can look it up in the tables presented [in the next
-section](#available-layers).
+page. You can look it up in the tables presented [in the next section](#available-layers).
 
 ## Available Layers
 
@@ -90,6 +88,7 @@ section](#available-layers).
 | [`gitsigns`](layers/GITSIGNS.md)         | Git code decorations                             |
 | [`grammarly`](layers/GRAMMARLY.md)       | Grammarly writing assistant support              |
 | [`languages`](layers/LANGUAGES.md)       | Enable [language layers](#language-layers)       |
+| [`lean`](layers/LEAN.md)                 | Lean proof assistant support                     |
 | [`lsp`](layers/LSP.md)                   | Manager for Neovim's LSP client and LSP servers  |
 | [`lspformat`](layers/LSPFORMAT.md)       | Formatting on save via LSP                       |
 | [`lspsignature`](layers/LSPSIGNATURE.md) | Function signatures as you type                  |
@@ -121,7 +120,7 @@ section](#available-layers).
 | [`json`](lang/JSON.md)             | JSON                  |
 | [`latex`](lang/LATEX.md)           | $\LaTeX$              |
 | [`lua`](lang/LUA.md)               | Lua                   |
-| [`ocaml`](lang/OCAML.md)           | OCaml                 |           
+| [`ocaml`](lang/OCAML.md)           | OCaml                 |
 | [`php`](lang/PHP.md)               | PHP                   |
 | [`python`](lang/PYTHON.md)         | Python                |
 | [`rust`](lang/RUST.md)             | Rust                  |

--- a/lua/visimp/layers/coq.lua
+++ b/lua/visimp/layers/coq.lua
@@ -1,7 +1,4 @@
 local L = require('visimp.layer').new_layer('coq')
-local get_module = require('visimp.bridge').get_module
-local get_layer = require('visimp.loader').get
-local opt = require('visimp.bridge').opt
 
 L.default_config = {}
 

--- a/lua/visimp/layers/lean.lua
+++ b/lua/visimp/layers/lean.lua
@@ -6,20 +6,18 @@ L.default_config = {
 }
 
 function L.dependencies()
-  return {}
+  return {
+    'lsp',
+  }
 end
 
 function L.packages()
   return {
     'Julian/lean.nvim',
-    'neovim/nvim-lspconfig',
-    'nvim-lua/plenary.nvim',
   }
 end
 
 function L.load()
-  vim.cmd('packadd nvim-lspconfig')
-  vim.cmd('packadd plenary.nvim')
   vim.cmd('packadd lean.nvim')
   get_module('lean').setup(L.config)
 end

--- a/lua/visimp/layers/lean.lua
+++ b/lua/visimp/layers/lean.lua
@@ -1,0 +1,27 @@
+local L = require('visimp.layer').new_layer('lean')
+local get_module = require('visimp.bridge').get_module
+
+L.default_config = {
+  mappings = true,
+}
+
+function L.dependencies()
+  return {}
+end
+
+function L.packages()
+  return {
+    'Julian/lean.nvim',
+    'neovim/nvim-lspconfig',
+    'nvim-lua/plenary.nvim',
+  }
+end
+
+function L.load()
+  vim.cmd('packadd nvim-lspconfig')
+  vim.cmd('packadd plenary.nvim')
+  vim.cmd('packadd lean.nvim')
+  get_module('lean').setup(L.config)
+end
+
+return L

--- a/lua/visimp/layers/lean.lua
+++ b/lua/visimp/layers/lean.lua
@@ -18,7 +18,6 @@ function L.packages()
 end
 
 function L.load()
-  vim.cmd('packadd lean.nvim')
   get_module('lean').setup(L.config)
 end
 


### PR DESCRIPTION
Closes #55. Also removed unused `require`s from the `coq` layer implementation (which I used as reference).

`neovim/nvim-lspconfig` is a hard package dependency. Maybe I should specify visimp's `lsp` layer as a dependency instead?