### PR TITLE
Config and doc for `snippet` layer

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -68,12 +68,12 @@ require 'visimp' {
 }
 ```
 
-Before configuring a new layer, you're advised to take a look at its reference
-page. You can look it up in the tables presented [in the next section](#available-layers).
-
 ## Available Layers
 
 ### Standard Layers
+
+Before configuring a new standard layer, you're advised to take a look at its
+reference page. You can look it up in the following table.
 
 | Layer name                               | Short description                                |
 | ---------------------------------------- | ------------------------------------------------ |
@@ -106,6 +106,10 @@ page. You can look it up in the tables presented [in the next section](#availabl
 | [`whichkey`](layers/WHICHKEY.md)         | Popups for key bindings suggestions              |
 
 ### Language layers
+
+Support for some of the programming languages that also double up as proof
+assistants (e.g. Coq, Lean) is provided by standard layers, rather than language
+layers.
 
 | Layer name   | Language              |
 | ------------ | --------------------- |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -107,28 +107,28 @@ page. You can look it up in the tables presented [in the next section](#availabl
 
 ### Language layers
 
-| Layer name                         | Language              |
-| ---------------------------------- | --------------------- |
-| [`ampl`](lang/AMPL.md)             | AMPL                  |
-| [`bash`](lang/BASH.md)             | Bash                  |
-| [`c`](lang/C.md)                   | C/C++                 |
-| [`csharp`](lang/CSHARP.md)         | C#                    |
-| [`css`](lang/CSS.md)               | CSS                   |
-| [`dart`](lang/DART.md)             | Dart                  |
-| [`go`](lang/GO.md)                 | Go                    |
-| [`haskell`](lang/HSKELL.md)        | Haskell               |
-| [`hcl`](lang/HCL.md)               | HCL                   |
-| [`html`](lang/HTML.md)             | HTML                  |
-| [`java`](lang/JAVA.md)             | Java                  |
-| [`javascript`](lang/JAVASCRIPT.md) | JavaScript/TypeScript |
-| [`json`](lang/JSON.md)             | JSON                  |
-| [`latex`](lang/LATEX.md)           | $\LaTeX$              |
-| [`lua`](lang/LUA.md)               | Lua                   |
-| [`ocaml`](lang/OCAML.md)           | OCaml                 |
-| [`php`](lang/PHP.md)               | PHP                   |
-| [`python`](lang/PYTHON.md)         | Python                |
-| [`rust`](lang/RUST.md)             | Rust                  |
-| [`svelte`](lang/SVELTE.md)         | Svelte                |
-| [`swift`](lang/SWIFT.md)           | Swift                 |
-| [`toml`](lang/TOML.md)             | TOML                  |
-| [`vue`](lang/VUE.md)               | Vue                   |
+| Layer name   | Language              |
+| ------------ | --------------------- |
+| `ampl`       | AMPL                  |
+| `bash`       | Bash                  |
+| `c`          | C/C++                 |
+| `csharp`     | C#                    |
+| `css`        | CSS                   |
+| `dart`       | Dart                  |
+| `go`         | Go                    |
+| `haskell`    | Haskell               |
+| `hcl`        | HCL                   |
+| `html`       | HTML                  |
+| `java`       | Java                  |
+| `javascript` | JavaScript/TypeScript |
+| `json`       | JSON                  |
+| `latex`      | $\LaTeX$              |
+| `lua`        | Lua                   |
+| `ocaml`      | OCaml                 |
+| `php`        | PHP                   |
+| `python`     | Python                |
+| `rust`       | Rust                  |
+| `svelte`     | Svelte                |
+| `swift`      | Swift                 |
+| `toml`       | TOML                  |
+| `vue`        | Vue                   |

--- a/docs/layers/SNIPPET.md
+++ b/docs/layers/SNIPPET.md
@@ -4,6 +4,15 @@ The `snippet` layer allows you to define code snippets via the
 [LuaSnip](https://github.com/l3mon4d3/luasnip) snippet engine. These may be
 specified using VS Code syntax, SnipMate syntax, or directly in Lua.
 
+## Bindings
+
+- `<Tab>` in insert mode: after typing snippet trigger, expands the snippet;
+- `<Tab>` in insert/selection mode: jumps to the next snippet stop;
+- `<S-Tab>` (shift + tab) in insert/selection mode: jumps to the previous
+  snippet stop;
+- `<C-E>` (ctrl + e) in insert/selection mode: cycles through options for
+  multiple choice snippet stops.
+
 ## Configuration
 
 - `setup`: setup settings for LuaSnip (as documented

--- a/docs/layers/SNIPPET.md
+++ b/docs/layers/SNIPPET.md
@@ -53,6 +53,10 @@ require("visimp")({
 
 ```snippets
 # path/of/your/nvim/config/snippets/haskell.snippets
+
+# "main" will be expanded as Haskell's main function. The editor will move to
+# the end of the snippet (where the main function implementation should be),
+# selecting the word "undefined", which acts as default implementation.
 snippet main
   main :: IO ()
   main = ${0:undefined}

--- a/docs/layers/SNIPPET.md
+++ b/docs/layers/SNIPPET.md
@@ -13,6 +13,8 @@ specified using VS Code syntax, SnipMate syntax, or directly in Lua.
 - `<C-E>` (ctrl + e) in insert/selection mode: cycles through options for
   multiple choice snippet stops.
 
+Bindings can be customized via the [`binds` layer](./BINDS.md).
+
 ## Configuration
 
 - `setup`: setup settings for LuaSnip (as documented
@@ -21,11 +23,6 @@ specified using VS Code syntax, SnipMate syntax, or directly in Lua.
   `vscode`) for Lua to load from the filesystem, and values are the respective
   configurations (as described
   [here](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#loaders)).
-
-## Layer-specific methods
-
-- `add_snippets(ft:string or nil, snippets:list or table, opts:table or nil)`:
-  wrapper for the homonym function from [LuaSnip's API](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#api-2).
 
 ## Examples
 
@@ -63,15 +60,40 @@ snippet main
 
 ```lua
 -- path/of/your/nvim/config/luasnippets/all.lua
-local ls = require("luasnip")
-local s = ls.snippet
-local t = ls.text_node
-return {
+local ls = require("luasnip") -- snippets are defined as trees
+local s = ls.snippet -- snippets constructor from trigger keyword and tree
+local t = ls.text_node -- plaintext node 
+
+return { -- this .lua file returns a list with just one snippet
+  -- "lorem" will be expanded as plaintext, non-interactive snippet "Lorem
+  -- ipsum dolor..."
   s("lorem", t("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))
 }
+```
+
+See the [documentation section](#documentation) to get familiar with LuaSnip.
+
+## Layer-specific API
+
+Other layers may interact with `snippet` via the following method.
+
+### `add_snippets(ldr:string, opts:table or nil)`
+
+A wrapper for [LuaSnip's lazy loading](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#api-2).
+The first parameter is either "vscode", "snipmate", or "lua". The second
+parameter is described in detail at the previous link.
+
+```lua
+local snippet = require('visimp.loader').get('snippet')
+
+snippet.add_snippets('vscode', { paths = '~/.config/nvim/my_snippets' })
 ```
 
 ## Documentation
 
 LuaSnip's README lists all kinds of [(un)official resources](https://github.com/l3mon4d3/luasnip?tab=readme-ov-file#documentation)
-for beginners and experienced users.
+for beginners and experienced users, including:
+
+- [LuaSnip's documentation](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md) (also available as `:help luasnip.txt`);
+- [LuaSnip's Lua snippets examples](https://github.com/L3MON4D3/LuaSnip/blob/master/Examples/snippets.lua);
+- [LuaSnip's wiki](https://github.com/L3MON4D3/LuaSnip/wiki).

--- a/docs/layers/SNIPPET.md
+++ b/docs/layers/SNIPPET.md
@@ -24,24 +24,24 @@ specified using VS Code syntax, SnipMate syntax, or directly in Lua.
 -- path/of/your/vim/config/init.lua
 
 require("visimp")({
-	snippet = {
-		setup = { -- LuaSnip setup configuration
-			update_events = { "TextChanged", "TextChangedI" },
-		},
-		loaders = {
-            -- load SnipMate-like snippets from
-            -- path/of/your/vim/config/snippets/. See below for an example.
-            snipmate = {}
-            -- load VS-Code-like snippets from any directory in your Neovim's
-            -- `runtimepath` containing at least one VS-Code-like package.json
-            -- contributing snippets. See
-            -- https://github.com/rafamadriz/friendly-snippets as an example.
-            vscode = {},
-            -- load snippets defined in Lua from
-            -- path/of/your/vim/config/luasnippets/. See below for an example.
-            lua = {},
-        },
-	},
+  snippet = {
+    setup = { -- LuaSnip setup configuration
+      update_events = { "TextChanged", "TextChangedI" },
+    },
+    loaders = {
+      -- load SnipMate-like snippets from
+      -- path/of/your/vim/config/snippets/. See below for an example.
+      snipmate = {}
+      -- load VS-Code-like snippets from any directory in your Neovim's
+      -- `runtimepath` containing at least one VS-Code-like package.json
+      -- contributing snippets. See
+      -- https://github.com/rafamadriz/friendly-snippets as an example.
+      vscode = {},
+      -- load snippets defined in Lua from
+      -- path/of/your/vim/config/luasnippets/. See below for an example.
+      lua = {},
+    },
+  },
 })
 ```
 

--- a/docs/layers/SNIPPET.md
+++ b/docs/layers/SNIPPET.md
@@ -48,8 +48,8 @@ require("visimp")({
 ```snippets
 # path/of/your/nvim/config/snippets/haskell.snippets
 snippet main
-	main :: IO ()
-	main = ${0:undefined}
+  main :: IO ()
+  main = ${0:undefined}
 ```
 
 ```lua
@@ -58,7 +58,7 @@ local ls = require("luasnip")
 local s = ls.snippet
 local t = ls.text_node
 return {
-	s("lorem", t("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))
+  s("lorem", t("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))
 }
 ```
 

--- a/docs/layers/SNIPPET.md
+++ b/docs/layers/SNIPPET.md
@@ -1,0 +1,68 @@
+# `snippet` layer
+
+The `snippet` layer allows you to define code snippets via the
+[LuaSnip](https://github.com/l3mon4d3/luasnip) snippet engine. These may be
+specified using VS Code syntax, SnipMate syntax, or directly in Lua.
+
+## Configuration
+
+- `setup`: setup settings for LuaSnip (as documented
+  [here](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#config-options));
+- `loaders`: a table whose keys are snippet types (`lua`, `snipmate`, or
+  `vscode`) for Lua to load from the filesystem, and values are the respective
+  configurations (as described
+  [here](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#loaders)).
+
+## Layer-specific methods
+
+- `add_snippets(ft:string or nil, snippets:list or table, opts:table or nil)`:
+  wrapper for the homonym function from [LuaSnip's API](https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#api-2).
+
+## Examples
+
+```lua
+-- path/of/your/vim/config/init.lua
+
+require("visimp")({
+	snippet = {
+		setup = { -- LuaSnip setup configuration
+			update_events = { "TextChanged", "TextChangedI" },
+		},
+		loaders = {
+            -- load SnipMate-like snippets from
+            -- path/of/your/vim/config/snippets/. See below for an example.
+            snipmate = {}
+            -- load VS-Code-like snippets from any directory in your Neovim's
+            -- `runtimepath` containing at least one VS-Code-like package.json
+            -- contributing snippets. See
+            -- https://github.com/rafamadriz/friendly-snippets as an example.
+            vscode = {},
+            -- load snippets defined in Lua from
+            -- path/of/your/vim/config/luasnippets/. See below for an example.
+            lua = {},
+        },
+	},
+})
+```
+
+```snippets
+# path/of/your/nvim/config/snippets/haskell.snippets
+snippet main
+	main :: IO ()
+	main = ${0:undefined}
+```
+
+```lua
+-- path/of/your/nvim/config/luasnippets/all.lua
+local ls = require("luasnip")
+local s = ls.snippet
+local t = ls.text_node
+return {
+	s("lorem", t("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))
+}
+```
+
+## Documentation
+
+LuaSnip's README lists all kinds of [(un)official resources](https://github.com/l3mon4d3/luasnip?tab=readme-ov-file#documentation)
+for beginners and experienced users.

--- a/lua/visimp/languages/agda.lua
+++ b/lua/visimp/languages/agda.lua
@@ -1,0 +1,40 @@
+local L = require('visimp.layer').new_layer('agda')
+local layers = require('visimp.loader')
+
+local function add_filetype()
+  vim.filetype.add({
+    extension = {
+      agda = 'agda',
+      ['agda-lib'] = 'agda',
+      lagda = 'lagda',
+    },
+  })
+end
+
+L.default_config = {
+  -- Leave to nil to use the official Agda Language Server, false to disable
+  lsp = nil,
+  -- Optional configuration to be provided for the chosen language server
+  lspconfig = nil,
+}
+
+function L.dependencies()
+  local deps = { 'treesitter' }
+  if L.config.lsp ~= false then
+    table.insert(deps, 'lsp')
+  end
+  return deps
+end
+
+function L.preload()
+  add_filetype()
+  -- Configure treesitter
+  layers.get('treesitter').langs({ 'agda' })
+
+  -- Enable the language server
+  if L.config.lsp ~= false then
+    -- Agda Language Server
+  end
+end
+
+return L

--- a/lua/visimp/languages/lua.lua
+++ b/lua/visimp/languages/lua.lua
@@ -2,7 +2,7 @@ local L = require('visimp.layer').new_layer('lua')
 local layers = require('visimp.loader')
 
 L.default_config = {
-  -- Leave to nil to use sumneko_lua LSP, otherwhise can specify local
+  -- Leave to nil to use lua_ls LSP, otherwhise can specify local
   -- installation or disable by setting to false.
   lsp = nil,
   -- Optional configuration to be provided for the chosen language server

--- a/lua/visimp/layers/snippet.lua
+++ b/lua/visimp/layers/snippet.lua
@@ -21,20 +21,24 @@ function L.packages()
   }
 end
 
-local function process_loader(snippets_loader, config)
+--- Adds additional snippets in VS Code/SnipMate/LuaSnip syntax.
+--- @param ldr string Snippets loader ('lua', 'snipmate', 'vscode')
+--- @param opts table|nil Options table
+--- @see https://github.com/L3MON4D3/LuaSnip/blob/master/DOC.md#loaders
+function L.add_snippets(ldr, opts)
   local available_loaders = { 'lua', 'snipmate', 'vscode' }
   for _, available_loader in pairs(available_loaders) do
-    if available_loader == snippets_loader then
-      require('luasnip.loaders.from_' .. snippets_loader).lazy_load(config)
+    if available_loader == ldr then
+      require('luasnip.loaders.from_' .. ldr).lazy_load(opts)
       return
     end
   end
-  error('"snippet" layer: unknown "' .. snippets_loader .. '" loader.')
+  error('"snippet" layer: add_snippets: unknown "' .. ldr .. '" loader.')
 end
 
 local function load_snippets(loaders)
   for snippets_loader, config in pairs(loaders) do
-    process_loader(snippets_loader, config)
+    L.add_snippets(snippets_loader, config)
   end
 end
 
@@ -137,10 +141,6 @@ function L.preload()
     end,
   })
   luasnip_setup()
-end
-
-function L.add_snippets(filetype, snippets, opts)
-  get_module('luasnip').add_snippets(filetype, snippets, opts)
 end
 
 return L

--- a/lua/visimp/layers/snippet.lua
+++ b/lua/visimp/layers/snippet.lua
@@ -1,6 +1,7 @@
 local L = require('visimp.layer').new_layer('snippet')
 local loader = require('visimp.loader')
 local get_module = require('visimp.bridge').get_module
+local bind = require('visimp.bind')
 
 L.default_config = {
   -- LuaSnip setup config
@@ -37,6 +38,27 @@ local function load_snippets(loaders)
   end
 end
 
+local function jump(ls, offset)
+  return function()
+    ls.jump(offset)
+  end
+end
+
+local function change_choice(ls)
+  return function()
+    if ls.choice_active() then
+      ls.change_choice(1)
+    end
+  end
+end
+
+local function luasnip_bindings(ls)
+  bind.map({ mode = 'i', bind = '<Tab>' }, ls.expand)
+  bind.map({ mode = { 'i', 's' }, bind = '<Tab>' }, jump(ls, 1))
+  bind.map({ mode = { 'i', 's' }, bind = '<S-Tab>' }, jump(ls, -1))
+  bind.map({ mode = { 'i', 's' }, bind = '<C-E>' }, change_choice(ls))
+end
+
 local function luasnip_setup()
   local luasnip = get_module('luasnip')
   local config = L.config
@@ -46,6 +68,7 @@ local function luasnip_setup()
   if config.loaders then
     load_snippets(config.loaders)
   end
+  luasnip_bindings(luasnip)
 end
 
 -- Taken from https://github.com/hrsh7th/nvim-cmp/wiki/Example-mappings#luasnip


### PR DESCRIPTION
The `snippet` layer has now some configuration options. They are described in its new doc page.

Incidentally:

- removed links to lang doc pages (not planned);
- fix reference to old sumneko_lua lsp in comment;
- `unpack` (deprecated) -> `table.unpack`;
- removed shadowing in snippet layer.