### PR TITLE
feat: idris language layer

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -106,32 +106,33 @@ reference page. You can look it up in the following table.
 
 ### Language layers
 
-| Layer name                  | Language              |
-| --------------------------- | --------------------- |
-| `agda`                      | Agda                  |
-| `ampl`                      | AMPL                  |
-| `bash`                      | Bash                  |
-| `c`                         | C/C++                 |
-| [`coq`](languages/COQ.md)   | Coq                   |
-| `csharp`                    | C#                    |
-| `css`                       | CSS                   |
-| `dart`                      | Dart                  |
-| `go`                        | Go                    |
-| `haskell`                   | Haskell               |
-| `hcl`                       | HCL                   |
-| `html`                      | HTML                  |
-| `java`                      | Java                  |
-| `javascript`                | JavaScript/TypeScript |
-| `json`                      | JSON                  |
-| `latex`                     | $\LaTeX$              |
-| [`lean`](languages/LEAN.md) | Lean                  |
-| `lua`                       | Lua                   |
-| `ocaml`                     | OCaml                 |
-| `php`                       | PHP                   |
-| `python`                    | Python                |
-| `rust`                      | Rust                  |
-| `svelte`                    | Svelte                |
-| `swift`                     | Swift                 |
-| `toml`                      | TOML                  |
-| `typst`                     | Typst                 |
-| `vue`                       | Vue                   |
+| Layer name                    | Language              |
+| ----------------------------- | --------------------- |
+| `agda`                        | Agda                  |
+| `ampl`                        | AMPL                  |
+| `bash`                        | Bash                  |
+| `c`                           | C/C++                 |
+| [`coq`](languages/COQ.md)     | Coq                   |
+| `csharp`                      | C#                    |
+| `css`                         | CSS                   |
+| `dart`                        | Dart                  |
+| `go`                          | Go                    |
+| `haskell`                     | Haskell               |
+| `hcl`                         | HCL                   |
+| `html`                        | HTML                  |
+| [`idris`](languages/IDRIS.md) | Idris                 |
+| `java`                        | Java                  |
+| `javascript`                  | JavaScript/TypeScript |
+| `json`                        | JSON                  |
+| `latex`                       | $\LaTeX$              |
+| [`lean`](languages/LEAN.md)   | Lean                  |
+| `lua`                         | Lua                   |
+| `ocaml`                       | OCaml                 |
+| `php`                         | PHP                   |
+| `python`                      | Python                |
+| `rust`                        | Rust                  |
+| `svelte`                      | Svelte                |
+| `swift`                       | Swift                 |
+| `toml`                        | TOML                  |
+| `typst`                       | Typst                 |
+| `vue`                         | Vue                   |

--- a/docs/languages/IDRIS.md
+++ b/docs/languages/IDRIS.md
@@ -1,0 +1,35 @@
+# `idris` layer
+
+The `idris` layer enables support for the Idris programming
+language via [idris2-vim](https://github.com/edwinb/idris2-vim). This plugin's
+documentation specifies its requirements.
+
+## Bindings
+
+Mappings are available [in the "Interactive Editing Commands" section of idris2-vim](https://github.com/edwinb/idris2-vim?tab=readme-ov-file#interactive-editing-commands).
+
+## Configuration
+
+This layer cannot be configured via visimp at the moment. Please refer to [the "Configuration" section of idris2-vim](https://github.com/edwinb/idris2-vim?tab=readme-ov-file#configuration)
+instead.
+
+## Examples
+
+```lua
+-- path/of/your/vim/config/init.lua
+
+require("visimp")({
+  languages = {
+  "idris" -- cannot be configured via visimp
+  }
+})
+
+vim.g.idris_indent_if = 3
+```
+
+## Documentation
+
+The full documentation for the plugin is available
+[here](https://github.com/edwinb/idris2-vim?tab=readme-ov-file). The plugin was
+written by Idris designer [Edwin Brady](https://type-driven.org.uk/edwinb), who
+also wrote [a blog post titled "Interactive Idris editing with vim"](https://web.archive.org/web/20170307061942if_/http://edwinb.wordpress.com/2013/10/28/interactive-idris-editing-with-vim/).

--- a/lua/visimp/languages/idris.lua
+++ b/lua/visimp/languages/idris.lua
@@ -1,0 +1,11 @@
+local L = require('visimp.layer').new_layer 'idris'
+
+function L.packages()
+  return { 'edwinb/idris2-vim' }
+end
+
+function L.load()
+  vim.cmd 'packadd idris2-vim'
+end
+
+return L


### PR DESCRIPTION
Closes #58. As https://github.com/mason-org/mason-registry/pull/5266 is still open, and no Treesitter parser or queries are available, I opted for the vimscript plugin designed by Idris' inventor. It features syntax highlighting, indentation, unicode character concealing, and some LSP-like interactive editing features.