### PR TITLE
feat: none-ls.nvim

### DIFF
--- a/docs/layers/LSP.md
+++ b/docs/layers/LSP.md
@@ -8,8 +8,9 @@ LSs are installed by [mason.nvim](https://github.com/williamboman/mason.nvim)
 by default.
 
 Neovim itself can also act as a LS to inject new LSP-like features via
-[null-ls.nvim](https://github.com/jose-elias-alvarez/null-ls.nvim) (discontinued
-project).
+[none-ls.nvim](https://github.com/nvimtools/none-ls.nvim), a community fork of
+the discontinued "null-ls.nvim". All documentation and code still refer to
+null-ls, as none-ls does not rename its API for compatibility concerns.
 
 ## Bindings
 

--- a/lua/visimp/layers/lsp.lua
+++ b/lua/visimp/layers/lsp.lua
@@ -104,7 +104,7 @@ function L.packages()
     -- other packages which have a hard dependency on plenary. This fix belongs
     -- to the package manager dependency resolution.
     'nvim-lua/plenary.nvim',
-    { 'jose-elias-alvarez/null-ls.nvim', opt = true },
+    { 'nvimtools/none-ls.nvim', opt = true },
     -- TODO: remove `branch: 'legacy'` once fidget.nvim has been rewritten
     { 'j-hui/fidget.nvim', opt = true, branch = 'legacy' },
   }


### PR DESCRIPTION
Replace discontinued `null-ls.nvim` with `none-ls.nvim`.