### PR TITLE
feat: upgrade which-key to v3

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -88,7 +88,7 @@ reference page. You can look it up in the following table.
 | [`fugitive`](layers/FUGITIVE.md)         | Git wrapper                                      |
 | [`gitsigns`](layers/GITSIGNS.md)         | Git code decorations                             |
 | [`icons`](layers/ICONS.md)               | Adds file type icons                             |
-| [`indentline`](layers/INDENTLINE.md)     | Whitespace characters visualization              |
+| [`indentline`](layers/BLANKLINE.md)      | Whitespace characters visualization              |
 | [`languages`](layers/LANGUAGES.md)       | Enable [language layers](#language-layers)       |
 | [`lsp`](layers/LSP.md)                   | Manager for Neovim's LSP client and LSP servers  |
 | [`lspformat`](layers/LSPFORMAT.md)       | Formatting on save via LSP                       |

--- a/docs/layers/BINDS.md
+++ b/docs/layers/BINDS.md
@@ -7,11 +7,11 @@ The `binds` layer allows you to define custom bindings declaratively.
 This layer's configuration is an array. Each key is a table, and must have the
 following fields:
 
- - `mode`: mode short name ([see `{mode}`](https://neovim.io/doc/user/lua.html#vim.keymap.set(%29));
- - `bind`: binding trigger ([see `{lhs}`](https://neovim.io/doc/user/lua.html#vim.keymap.set(%29));
- - `opts`: addtional (non-mandatory) options ([see `{opts}`](https://neovim.io/doc/user/lua.html#vim.keymap.set(%29));
- - `desc`: a description of the binding (used by the [`whichkey`
-   layer](WHICKKEY.md)).
+ - `mode`: mode short name ([see `{mode}`](https://neovim.io/doc/user/lua.html#vim.keymap.set(%29)));
+ - `bind`: binding trigger ([see `{lhs}`](https://neovim.io/doc/user/lua.html#vim.keymap.set(%29)));
+ - `opts`: additional (non-mandatory) options ([see `{opts}`](https://neovim.io/doc/user/lua.html#vim.keymap.set(%29))).
+   Should contain `desc`, a description of the binding (used by the [`whichkey`
+   layer](WHICHKEY.md)).
 
 Each value is a function to be invoked when the binding is triggered.
 
@@ -23,11 +23,13 @@ Each value is a function to be invoked when the binding is triggered.
 require("visimp")({
   binds = {
     [{
-      mode = 'n',                 -- When in normal mode...
-      bind = '<leader>h',         -- and pressing <leader>h...
-      desc = 'Show date and time' -- (description for whichkey layer)
+      mode = 'n',                   -- When in normal mode...
+      bind = '<leader>h',           -- and pressing <leader>h...
+      opts = {
+        desc = 'Show date and time' -- (description for whichkey layer)
+      }
     }] = function ()
-      print(os.date())            -- ...print the current date and time
+      print(os.date())              -- ...print the current date and time
     end
   }
 })

--- a/docs/layers/LSP.md
+++ b/docs/layers/LSP.md
@@ -81,9 +81,18 @@ layers.get('lsp').use_server('go', true, 'gopls', {})
 Adds an "on-attach"-like handler to be invoked when LSs get enabled for a
 buffer.
 
+### `on_attach_one_time(fn:function)`
+
+Adds an "on-attach"-like handler to be invoked each time a buffer sees an LS
+enabled for the first time.
+
 ### `get_callbacks()`
 
 Returns the list of "on-attach"-like handlers.
+
+### `get_callbacks_one_time()`
+
+Returns the list of "on-attach-one-time"-like handlers.
 
 ### `get_capabilities()`
 

--- a/docs/layers/WHICHKEY.md
+++ b/docs/layers/WHICHKEY.md
@@ -25,14 +25,9 @@ require("visimp")({
 
 ## Layer-specific API
 
-### `register(binds)`
+### `add(mappings)`
 
-Makes all values in the list passed as `binds` available to which-key. Each
-value is a bind as those described by the [`binds` layer's "Configuration"
-section](BINDS.md#configuration).
-
-### `register_all()`
-
-This method ensures all keybindings are registered, at the cost of duplicate
-registrations. Those will cause an innocuous warning in `:checkhealth
-which-key`.
+Just a wrapper for `whichkey`'s `add` method. Under normal circumstances,
+[there is no need to call this method or do anything
+else](https://github.com/folke/which-key.nvim#%EF%B8%8F-mappings) to have one's
+mappings show up.

--- a/docs/layers/WHICHKEY.md
+++ b/docs/layers/WHICHKEY.md
@@ -27,11 +27,12 @@ require("visimp")({
 
 ### `register(binds)`
 
-Makes all values in `binds` available to which-key. Each value is a bind as
-those described by the [`binds` layer's "Configuration"
+Makes all values in the list passed as `binds` available to which-key. Each
+value is a bind as those described by the [`binds` layer's "Configuration"
 section](BINDS.md#configuration).
 
 ### `register_all()`
 
-This method ensures all keybindings are registered. It is also run when a new
-LSP layer is attached to a buffer.
+This method ensures all keybindings are registered, at the cost of duplicate
+registrations. Those will cause an innocuous warning in `:checkhealth
+which-key`.

--- a/docs/layers/WHICHKEY.md
+++ b/docs/layers/WHICHKEY.md
@@ -25,6 +25,12 @@ require("visimp")({
 
 ## Layer-specific API
 
+### `register(binds)`
+
+Makes all values in `binds` available to which-key. Each value is a bind as
+those described by the [`binds` layer's "Configuration"
+section](BINDS.md#configuration).
+
 ### `register_all()`
 
 This method ensures all keybindings are registered. It is also run when a new

--- a/lua/visimp/bind.lua
+++ b/lua/visimp/bind.lua
@@ -33,11 +33,27 @@ function M.get_registered()
   return M.registered
 end
 
+---Sets the buffer of the given key.
+---@param key table A key object for a bind.
+---@param buffer integer|nil A buffer number, or nil if the bind is meant to be
+---global.
+local function set_buffer(key, buffer)
+  if not buffer then
+    return
+  end
+  if not key.opts then
+    key.opts = {}
+  end
+  key.opts.buffer = buffer
+end
+
 --- Sets up the list of binds with the given list/function of handlers
 -- @param binds The list of binds in a correct format
 -- @param handler Either a table of bind actions of a function for manually
 --                assigning a bind function to a key
-function M.bind(binds, handler)
+-- @param buffer integer|nil A buffer identifier if all binds want to be
+-- registered as local to a certain buffer. Nil otherwhise.
+function M.bind(binds, handler, buffer)
   if
     type(handler) ~= 'function'
     and type(handler) ~= 'table'
@@ -59,6 +75,7 @@ function M.bind(binds, handler)
     local hndlr = handler == nil and exec
       or type(handler) == 'table' and handler[exec]
       or handler(exec)
+    set_buffer(key, buffer)
     M.map(key, hndlr)
   end
 end

--- a/lua/visimp/layers/diagnostics.lua
+++ b/lua/visimp/layers/diagnostics.lua
@@ -1,6 +1,7 @@
 local L = require('visimp.layer').new_layer 'diagnostics'
 local bind = require('visimp.bind').bind
 local get_module = require('visimp.bridge').get_module
+local get_layer = require('visimp.loader').get
 
 ---Returns a function toggling the view with the given mode and filters.
 ---@param mode string Mode to be toggled
@@ -22,32 +23,44 @@ L.default_config = {
     [{
       mode = 'n',
       bind = '<leader>xx',
-      desc = 'Diagnostics',
+      opts = {
+        desc = 'Diagnostics',
+      },
     }] = make_toggle 'diagnostics',
     [{
       mode = 'n',
       bind = '<leader>xX',
-      desc = 'Buffer Diagnostics',
+      opts = {
+        desc = 'Buffer Diagnostics',
+      },
     }] = make_toggle('diagnostics', 'filter.buf=0'),
     [{
       mode = 'n',
       bind = '<leader>cs',
-      desc = 'Symbols',
+      opts = {
+        desc = 'Symbols',
+      },
     }] = make_toggle('symbols', 'focus=false'),
     [{
       mode = 'n',
       bind = '<leader>cl',
-      desc = 'LSP definitions/references/...',
+      opts = {
+        desc = 'LSP definitions/references/...',
+      },
     }] = make_toggle('lsp', 'focus=false win.position=right'),
     [{
       mode = 'n',
       bind = '<leader>xL',
-      desc = 'Location list',
+      opts = {
+        desc = 'Location list',
+      },
     }] = make_toggle 'loclist',
     [{
       mode = 'n',
       bind = '<leader>xQ',
-      desc = 'Quickfix list',
+      opts = {
+        desc = 'Quickfix list',
+      },
     }] = make_toggle 'qflist',
   },
 }
@@ -64,9 +77,13 @@ function L.packages()
   }
 end
 
+local function on_attach(_, bufnr)
+  bind(L.config.binds, nil, bufnr)
+end
+
 function L.load()
   get_module('trouble').setup(L.config.trouble)
-  bind(L.config.binds, nil)
+  get_layer('lsp').on_attach_one_time(on_attach)
 end
 
 return L

--- a/lua/visimp/layers/telescope.lua
+++ b/lua/visimp/layers/telescope.lua
@@ -21,12 +21,16 @@ L.default_config = {
     [{
       mode = 'n',
       bind = '<leader>p',
-      desc = 'Find files by their name',
+      opts = {
+        desc = 'Find files by their name',
+      },
     }] = 'find_files',
     [{
       mode = 'n',
       bind = '<leader>f',
-      desc = 'Search through files content',
+      opts = {
+        desc = 'Search through files content',
+      },
     }] = 'live_grep',
   },
 }

--- a/lua/visimp/layers/whichkey.lua
+++ b/lua/visimp/layers/whichkey.lua
@@ -1,15 +1,9 @@
 local L = require('visimp.layer').new_layer 'whichkey'
 local get_module = require('visimp.bridge').get_module
-local get_visimp_registered = require('visimp.bind').get_registered
-local get_layer = require('visimp.loader').get
 
 -- All fields from
--- https://github.com/folke/which-key.nvim#%EF%B8%8F-configuration are allowed.
+-- https://github.com/folke/which-key.nvim#%EF%B8%8F-configuration
 L.default_config = {}
-
--- True just in case the LSP layer binds have already been registered to
--- which-key. This is done after the first LS is attached to a buffer.
-L.lsp_binds_are_loaded = false
 
 function L.dependencies()
   return { 'lsp' }
@@ -19,82 +13,15 @@ function L.packages()
   return { 'folke/which-key.nvim' }
 end
 
----Given a table, computes a list of its keys in an arbitrary order.
----@param t table The table whose list are to be enumerated
----@return table l The computed list of keys
-local function keys(t)
-  local res = {}
-  for key, _ in pairs(t) do
-    table.insert(res, key)
-  end
-  return res
-end
-
----Maps a function over a list, generating a new list with the output values.
----The original list is left inaltered.
----@param f function The function producing the output values
----@param l table The list to map over
----@return table res The resulting list
-local function map(f, l)
-  local res = {}
-  for i, v in ipairs(l) do
-    table.insert(res, i, f(v))
-  end
-  return res
-end
-
----Gets the LSP layer used by which-key.
-local function get_lsp_layer()
-  return get_layer 'lsp'
-end
-
----Converts a bind table from the [visimp format](../../../docs/layers/BINDS.md)
----to the [which-key
----format](https://github.com/folke/which-key.nvim#%EF%B8%8F-mappings).
----@param visimp_bind table A bind in the visimp format
----@return table out A bind in the which-key format
-local function visimp_bind_to_whichkey_bind(visimp_bind)
-  return {
-    visimp_bind.bind,
-    desc = visimp_bind.desc or visimp_bind.rhs or '',
-    mode = visimp_bind.mode,
-  }
-end
-
----Generates a new table with all current bindings managed by visimp. All the
----bindings are presented in the [which-key
----format](https://github.com/folke/which-key.nvim#%EF%B8%8F-mappings).
----@return table out The generated table
-local function visimp_binds_to_whichkey_binds(visimp_binds)
-  return map(visimp_bind_to_whichkey_bind, visimp_binds)
-end
-
----Registers some bindings passed in the [visimp
----format](../../../docs/layers/BINDS.md).
----@param binds table List of binds to register.
-function L.register(binds)
-  get_module('which-key').add(visimp_binds_to_whichkey_binds(binds))
-end
-
----Registers LSP-related binds if those have not been registered already.
-function L.register_lsp()
-  if not L.lsp_binds_are_loaded then
-    L.register(keys(get_lsp_layer().config.binds))
-    L.lsp_binds_are_loaded = true
-  end
-end
-
----Registers all bindings currently known by visimp. Bindings are already
----registered by this plugin at loading time, so invoking this method by
----register some bindings a second time.
-function L.register_all()
-  L.register(get_visimp_registered())
-end
-
 function L.load()
   get_module('which-key').setup(L.config or {})
-  get_lsp_layer().on_attach(L.register_lsp)
-  L.register_all()
+end
+
+---Wrapper for `whichkey`'s `add` method.
+---@param mappings table List of mappings to be added manually. Normally,
+---mappings are added without any need to invoke this method.
+function L.add(mappings)
+  get_module('which-key').add(mappings)
 end
 
 return L

--- a/lua/visimp/layers/whichkey.lua
+++ b/lua/visimp/layers/whichkey.lua
@@ -4,8 +4,12 @@ local get_visimp_registered = require('visimp.bind').get_registered
 local get_layer = require('visimp.loader').get
 
 -- All fields from
--- https://github.com/folke/which-key.nvim#%EF%B8%8F-configuration
+-- https://github.com/folke/which-key.nvim#%EF%B8%8F-configuration are allowed.
 L.default_config = {}
+
+-- True just in case the LSP layer binds have already been registered to
+-- which-key. This is done after the first LS is attached to a buffer.
+L.lsp_binds_are_loaded = false
 
 function L.dependencies()
   return { 'lsp' }
@@ -15,13 +19,15 @@ function L.packages()
   return { 'folke/which-key.nvim' }
 end
 
-function L.load()
-  get_module('which-key').setup(L.config or {})
-  local lsp = get_layer 'lsp'
-  lsp.on_attach(function()
-    L.register(lsp.config.binds)
-  end)
-  L.register_all()
+---Given a table, computes a list of its keys in an arbitrary order.
+---@param t table The table whose list are to be enumerated
+---@return table l The computed list of keys
+local function keys(t)
+  local res = {}
+  for key, _ in pairs(t) do
+    table.insert(res, key)
+  end
+  return res
 end
 
 ---Maps a function over a list, generating a new list with the output values.
@@ -35,6 +41,11 @@ local function map(f, l)
     table.insert(res, i, f(v))
   end
   return res
+end
+
+---Gets the LSP layer used by which-key.
+local function get_lsp_layer()
+  return get_layer 'lsp'
 end
 
 ---Converts a bind table from the [visimp format](../../../docs/layers/BINDS.md)
@@ -65,11 +76,25 @@ function L.register(binds)
   get_module('which-key').add(visimp_binds_to_whichkey_binds(binds))
 end
 
+---Registers LSP-related binds if those have not been registered already.
+function L.register_lsp()
+  if not L.lsp_binds_are_loaded then
+    L.register(keys(get_lsp_layer().config.binds))
+    L.lsp_binds_are_loaded = true
+  end
+end
+
 ---Registers all bindings currently known by visimp. Bindings are already
 ---registered by this plugin at loading time, so invoking this method by
 ---register some bindings a second time.
 function L.register_all()
   L.register(get_visimp_registered())
+end
+
+function L.load()
+  get_module('which-key').setup(L.config or {})
+  get_lsp_layer().on_attach(L.register_lsp)
+  L.register_all()
 end
 
 return L

--- a/lua/visimp/layers/whichkey.lua
+++ b/lua/visimp/layers/whichkey.lua
@@ -1,6 +1,6 @@
 local L = require('visimp.layer').new_layer 'whichkey'
 local get_module = require('visimp.bridge').get_module
-local get_registered = require('visimp.bind').get_registered
+local get_visimp_registered = require('visimp.bind').get_registered
 local get_layer = require('visimp.loader').get
 
 -- All fields from
@@ -17,17 +17,59 @@ end
 
 function L.load()
   get_module('which-key').setup(L.config or {})
-  get_layer('lsp').on_attach(L.register_all)
+  local lsp = get_layer 'lsp'
+  lsp.on_attach(function()
+    L.register(lsp.config.binds)
+  end)
   L.register_all()
 end
 
-function L.register_all()
-  local whichkey = get_module 'which-key'
-  local defs = {}
-  for _, l in ipairs(get_registered()) do
-    defs[l.bind] = l.desc or l.rhs or ''
+---Maps a function over a list, generating a new list with the output values.
+---The original list is left inaltered.
+---@param f function The function producing the output values
+---@param l table The list to map over
+---@return table res The resulting list
+local function map(f, l)
+  local res = {}
+  for i, v in ipairs(l) do
+    table.insert(res, i, f(v))
   end
-  whichkey.register(defs)
+  return res
+end
+
+---Converts a bind table from the [visimp format](../../../docs/layers/BINDS.md)
+---to the [which-key
+---format](https://github.com/folke/which-key.nvim#%EF%B8%8F-mappings).
+---@param visimp_bind table A bind in the visimp format
+---@return table out A bind in the which-key format
+local function visimp_bind_to_whichkey_bind(visimp_bind)
+  return {
+    visimp_bind.bind,
+    desc = visimp_bind.desc or visimp_bind.rhs or '',
+    mode = visimp_bind.mode,
+  }
+end
+
+---Generates a new table with all current bindings managed by visimp. All the
+---bindings are presented in the [which-key
+---format](https://github.com/folke/which-key.nvim#%EF%B8%8F-mappings).
+---@return table out The generated table
+local function visimp_binds_to_whichkey_binds(visimp_binds)
+  return map(visimp_bind_to_whichkey_bind, visimp_binds)
+end
+
+---Registers some bindings passed in the [visimp
+---format](../../../docs/layers/BINDS.md).
+---@param binds table List of binds to register.
+function L.register(binds)
+  get_module('which-key').add(visimp_binds_to_whichkey_binds(binds))
+end
+
+---Registers all bindings currently known by visimp. Bindings are already
+---registered by this plugin at loading time, so invoking this method by
+---register some bindings a second time.
+function L.register_all()
+  L.register(get_visimp_registered())
 end
 
 return L


### PR DESCRIPTION
When updating the which-key.nvim plugin to version 3 w/o these changes, a warning would show up:

```
here were issues reported with your **which-key** mappings.
Use `:checkhealth which-key` to find out more.
```

Invoking `:checkhealth which-key` explains the problem:

```
Checking for issues with your mappings
- WARNING You're using an old version of the which-key spec.
  Your mappings will work, but it's recommended to update them to the new version.
  Please check the docs and suggested spec below for more info.
  Mappings:
  {
    ["<C-E>"] = "Next snippet tabstop option",
    ["<leader>f"] = "Search through files content",
    ["<leader>p"] = "Find files by their name"
  }

  -- Suggested Spec:
  {
    { "<C-E>", desc = "Next snippet tabstop option" },
    { "<leader>f", desc = "Search through files content" },
    { "<leader>p", desc = "Find files by their name" },
  }
```

This PR upgrades to v3 of which-key specs. In addition, now LSP bindings are not registered twice (but only once, when the LSP is attached), which also removes the related warnings.